### PR TITLE
Add support for custom Launcher options

### DIFF
--- a/junit-platform-isolator-base-8/pom.xml
+++ b/junit-platform-isolator-base-8/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.sormuras.junit</groupId>
         <artifactId>junit-platform-isolator-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-M11</version>
     </parent>
 
     <artifactId>junit-platform-isolator-base-8</artifactId>

--- a/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/Configuration.java
+++ b/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/Configuration.java
@@ -18,6 +18,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -329,6 +331,7 @@ public class Configuration implements Serializable {
 
     boolean testEngineAutoRegistration = true;
     boolean testExecutionListenerAutoRegistration = true;
+    Collection<String> additionalTestEngines = new ArrayList<>();
 
     private Launcher() {}
 
@@ -340,19 +343,24 @@ public class Configuration implements Serializable {
       return testExecutionListenerAutoRegistration;
     }
 
+    public Collection<String> getAdditionalTestEngines() {
+      return additionalTestEngines;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
       if (!(o instanceof Launcher)) return false;
       Launcher launcher = (Launcher) o;
       return testEngineAutoRegistration == launcher.testEngineAutoRegistration
-          && testExecutionListenerAutoRegistration
-              == launcher.testExecutionListenerAutoRegistration;
+          && testExecutionListenerAutoRegistration == launcher.testExecutionListenerAutoRegistration
+          && additionalTestEngines.equals(((Launcher) o).additionalTestEngines);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(testEngineAutoRegistration, testExecutionListenerAutoRegistration);
+      return Objects.hash(
+          testEngineAutoRegistration, testExecutionListenerAutoRegistration, additionalTestEngines);
     }
 
     @Override
@@ -360,6 +368,7 @@ public class Configuration implements Serializable {
       return new StringJoiner(", ", Launcher.class.getSimpleName() + "[", "]")
           .add("testEngineAutoRegistration=" + testEngineAutoRegistration)
           .add("testExecutionListenerAutoRegistration=" + testExecutionListenerAutoRegistration)
+          .add("additionalTestEngines=" + additionalTestEngines)
           .toString();
     }
   }

--- a/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/ConfigurationBuilder.java
+++ b/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/ConfigurationBuilder.java
@@ -400,5 +400,11 @@ public class ConfigurationBuilder {
       configuration.launcher().testExecutionListenerAutoRegistration = enabled;
       return this;
     }
+
+    /** Collection of additional test engines. */
+    public LauncherBuilder setAdditionalTestEngines(Collection<String> additionalTestEngines) {
+      configuration.launcher().additionalTestEngines = additionalTestEngines;
+      return this;
+    }
   }
 }

--- a/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/Version.java
+++ b/junit-platform-isolator-base-8/src/main/java/de/sormuras/junit/platform/isolator/Version.java
@@ -17,7 +17,7 @@ import java.util.function.UnaryOperator;
 /** Maven artifact version defaults. */
 public enum Version {
   /** {@code isolator.version} */
-  ISOLATOR_VERSION(implementationVersion("1.0.0-SNAPSHOT"), ISOLATOR, ISOLATOR_WORKER),
+  ISOLATOR_VERSION(implementationVersion("1.0.0-M11"), ISOLATOR, ISOLATOR_WORKER),
 
   /** {@code junit.platform.version} */
   JUNIT_PLATFORM_VERSION("1.3.2", JUNIT_PLATFORM_COMMONS),

--- a/junit-platform-isolator-base-8/src/test/java/de/sormuras/junit/platform/isolator/GroupArtifactVersionTests.java
+++ b/junit-platform-isolator-base-8/src/test/java/de/sormuras/junit/platform/isolator/GroupArtifactVersionTests.java
@@ -53,7 +53,7 @@ class GroupArtifactVersionTests {
   void passingNullAsVersionToCreateArtifactVersionMap() {
     Map<String, String> map = Version.buildMap(__ -> null);
     assertEquals(SIZE, map.size(), "map=" + map);
-    assertEquals("1.0.0-SNAPSHOT", map.get("isolator.version"));
+    assertEquals("1.0.0-M11", map.get("isolator.version"));
     assertEquals("1.3.2", map.get("junit.platform.version"));
     assertEquals("5.3.2", map.get("junit.jupiter.version"));
     assertEquals("5.3.2", map.get("junit.vintage.version"));

--- a/junit-platform-isolator-java-11/pom.xml
+++ b/junit-platform-isolator-java-11/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.sormuras.junit</groupId>
         <artifactId>junit-platform-isolator-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-M11</version>
     </parent>
 
     <artifactId>junit-platform-isolator-java-11</artifactId>

--- a/junit-platform-isolator-worker/pom.xml
+++ b/junit-platform-isolator-worker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.sormuras.junit</groupId>
         <artifactId>junit-platform-isolator-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-M11</version>
     </parent>
 
     <artifactId>junit-platform-isolator-worker</artifactId>

--- a/junit-platform-isolator-worker/src/main/java/de/sormuras/junit/platform/isolator/worker/LauncherCreator.java
+++ b/junit-platform-isolator-worker/src/main/java/de/sormuras/junit/platform/isolator/worker/LauncherCreator.java
@@ -1,6 +1,12 @@
 package de.sormuras.junit.platform.isolator.worker;
 
 import de.sormuras.junit.platform.isolator.Configuration;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.junit.platform.engine.TestEngine;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherFactory;
@@ -19,6 +25,34 @@ class LauncherCreator {
     builder.enableTestEngineAutoRegistration(configuration.isTestEngineAutoRegistration());
     builder.enableTestExecutionListenerAutoRegistration(
         configuration.isTestExecutionListenerAutoRegistration());
+    if (configuration.getAdditionalTestEngines() != null) {
+      builder.addTestEngines(toArray(instantiateClasses(configuration.getAdditionalTestEngines())));
+    }
     return LauncherFactory.create(builder.build());
+  }
+
+  private TestEngine[] toArray(Collection<TestEngine> collection) {
+    return collection.toArray(new TestEngine[collection.size()]);
+  }
+
+  private Collection<TestEngine> instantiateClasses(final Collection<String> classes) {
+    return classes.stream()
+        .map(this::classToInstance)
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  private TestEngine classToInstance(final String clazz) {
+    try {
+      Class<?> aClass = Class.forName(clazz);
+      Constructor<?> constructor = aClass.getConstructor();
+      return (TestEngine) constructor.newInstance();
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException(e);
+    } catch (InvocationTargetException
+        | NoSuchMethodException
+        | IllegalAccessException
+        | InstantiationException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/junit-platform-isolator/pom.xml
+++ b/junit-platform-isolator/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.sormuras.junit</groupId>
         <artifactId>junit-platform-isolator-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-M11</version>
     </parent>
 
     <artifactId>junit-platform-isolator</artifactId>

--- a/junit-platform-isolator/src/test/java/ConfigurationBuilderTests.java
+++ b/junit-platform-isolator/src/test/java/ConfigurationBuilderTests.java
@@ -2,6 +2,7 @@ import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 
 import de.sormuras.junit.platform.isolator.ConfigurationBuilder;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +44,8 @@ class ConfigurationBuilderTests {
         .launcher()
         .setTestEngineAutoRegistration(false)
         .setTestExecutionListenerAutoRegistration(false)
+        .setAdditionalTestEngines(
+            Collections.singletonList("de.sormuras.junit.platform.CustomTestEngine"))
         .end()
         .setDryRun(false);
 
@@ -80,7 +83,8 @@ class ConfigurationBuilderTests {
             + "], "
             + "launcher=Launcher["
             + "testEngineAutoRegistration=false, "
-            + "testExecutionListenerAutoRegistration=false"
+            + "testExecutionListenerAutoRegistration=false, "
+            + "additionalTestEngines=[de.sormuras.junit.platform.CustomTestEngine]"
             + "]"
             + "}";
     assertLinesMatch(lines(expected), lines(configuration.toString()));

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <plugin>
                 <groupId>de.sormuras.junit</groupId>
                 <artifactId>junit-platform-maven-plugin</artifactId>
-                <version>1.0.0-M5</version>
+                <version>1.2.0-SNAPSHOT</version>
                 <extensions>true</extensions>
                 <configuration>
                     <isolation>ABSOLUTE</isolation>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.sormuras.junit</groupId>
     <artifactId>junit-platform-isolator-root</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-M11</version>
     <packaging>pom</packaging>
 
     <name>JUnit Platform Isolator</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.sormuras.junit</groupId>
         <artifactId>junit-platform-isolator-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-M11</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/src/test/java/tests/Tests.java
+++ b/tests/src/test/java/tests/Tests.java
@@ -78,7 +78,7 @@ class Tests {
       var source = Files.readString(path);
       var target =
           source
-              .replaceAll("@project.version@", "1.0.0-SNAPSHOT")
+              .replaceAll("@project.version@", "1.0.0-M11")
               .replaceAll("@junit.jupiter.version@", "5.3.2");
       Files.writeString(path, target);
     } catch (IOException e) {


### PR DESCRIPTION
The goal of this change is to expose the Launcher configuration outside the maven plugin to give more fine-grained control over the TestEngine instances that are used in the test runs.